### PR TITLE
Modify builder behavior to avoid nested dependencies

### DIFF
--- a/lambda/STARK_CodeGen_Dynamic/cgdynamic_builder.py
+++ b/lambda/STARK_CodeGen_Dynamic/cgdynamic_builder.py
@@ -28,7 +28,7 @@ def create():
 
             for dependency in func_def['Dependencies']:
                 #Copy entire Lambda module code (folder)
-                os.system(f"cp -R lambda/{{dependency}} lambda/{{stark_func}}")
+                os.system(f"cp -R lambda_src/{{dependency}} lambda/{{stark_func}}")
     """
     return textwrap.dedent(source_code)
 

--- a/lambda/STARK_CodeGen_Dynamic/cgdynamic_buildspec.py
+++ b/lambda/STARK_CodeGen_Dynamic/cgdynamic_buildspec.py
@@ -24,6 +24,7 @@ def create(data):
                 - BUCKET=$(cat template_configuration.json | python3 -c "import sys, json; print(json.load(sys.stdin)['Parameters']['UserCICDPipelineBucketNameParameter'])")
                 - WEBSITE=$(cat template_configuration.json | python3 -c "import sys, json; print(json.load(sys.stdin)['Parameters']['UserWebsiteBucketNameParameter'])")
                 - sed -i "s/RandomTokenFromBuildScript/$(date)/" template.yml
+                - cp -R lambda lambda_src
                 - pip install pyyaml
                 - python3 ./builder.py
                 - aws cloudformation package --template-file template.yml --s3-bucket $BUCKET --s3-prefix {project_varname} --output-template-file outputtemplate.yml


### PR DESCRIPTION
Hi Nic,

Simple change in builder.py and buildspec.yml to avoid inadvertent nested folders in dependencies - the bug we observed last week.

Buildspec.yml now creates a duplicate folder first, "lambda_src".

Builder.py copies lambda folders from "lambda_src", ensuring it is always pristine / vanilla.